### PR TITLE
Add `setup-android` step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -116,6 +116,10 @@ runs:
         distribution: adopt
         cache: gradle
 
+    - name: Install Android SDK Tools
+      if: ${{ !steps.find-artifact.outputs.artifact-url }}
+      uses: android-actions/setup-android@v3
+
     - name: Validate Gradle wrapper
       if: ${{ inputs.validate-gradle-wrapper == 'true' && !steps.find-artifact.outputs.artifact-url }}
       uses: gradle/actions/wrapper-validation@v4


### PR DESCRIPTION
Thanks for the RNEF suite, it's amazing!

We've come though this issue when using our self-hosted runner, which does not come with the [pre-installed android tools](https://github.com/actions/runner-images/blob/ubuntu24/20250602.3/images/ubuntu/Ubuntu2404-Readme.md#android).

Resultiing in the following error:

```bash
◇  Failed to build the app
│
■  * Where:
│  Build file '/home/runner/_work/my-app/my-app/android/build.gradle' line: 80
│  
│  * What went wrong:
│  A problem occurred evaluating root project 'gympass'.
│  > Failed to apply plugin 'com.facebook.react.rootproject'.
│     > A problem occurred configuring project ':app'.
│        > SDK location not found. Define a valid SDK location with an ANDROID_HOME environment variable or by setting the sdk.dir path in your project's local properties file at '/home/runner/_work/my-app/my-app/android/local.properties'.
│
■  RnefError: Failed to build the app. See the error above for details from Gradle.
│      at runGradle (file:///home/runner/_work/my-app/my-app/node_modules/@rnef/platform-android/dist/src/lib/commands/runGradle.js:47:15)
│      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
│      at async buildAndroid (file:///home/runner/_work/my-app/my-app/node_modules/@rnef/platform-android/dist/src/lib/commands/buildAndroid/buildAndroid.js:17:5)
│      at async Object.action (file:///home/runner/_work/my-app/my-app/node_modules/@rnef/platform-android/dist/src/lib/commands/buildAndroid/command.js:9:13)
│      at async Command.<anonymous> (file:///home/runner/_work/my-app/my-app/node_modules/@rnef/cli/dist/src/lib/cli.js:39:17)
│      at async Command.parseAsync (/home/runner/_work/my-app/my-app/node_modules/commander/lib/command.js:1092:5)
│      at async cli (file:///home/runner/_work/my-app/my-app/node_modules/@rnef/cli/dist/src/lib/cli.js:74:5) {
│    [cause]: undefined
│  }
Error: Process completed with exit code 1.
```

To "solve" this issue, we've manually added the `actions/setup-java` and `android-actions/setup-android` (we can't add only the setup-android one since it depends on the Java installation) on our workflow, but that's a bit problematic, since `callstackincubator/android` also calls `actions/setup-java`, we end up with two post-install jobs and caches.

This PR add's the `android-actions/setup-android` action directly under the `callstackincubator/android` action, just like `actions/setup-java`.

