### PR TITLE
feat: adhoc upload step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -324,6 +324,8 @@ runs:
         echo "ARTIFACT_URL=$(echo "$OUTPUT" | jq -r '.url')" >> $GITHUB_ENV
       shell: bash
 
+    # For ad-hoc builds, the ARTIFACT_NAME may contain PR-number, while Rock will save the artifact without PR trait in its cache.
+    # We need to upload the artifact with the PR-number in the name, that's why we use --binary-path with appropriate ARTIFACT_PATH that accounts for it.
     - name: Upload for Ad-hoc distribution
       if: ${{ env.PROVIDER_NAME != 'GitHub' && inputs.ad-hoc == 'true' }}
       run: |


### PR DESCRIPTION
This PR adds ad-hoc distribution support for Android builds
- New input parameter ad-hoc (boolean, default: false)
- New workflow step "Upload for Ad-hoc distribution"
- Uploads the binary with an index.html wrapper page for easy browser-based installation