### PR TITLE
fix: allow space in binary path artifact name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -263,7 +263,7 @@ runs:
     - name: Re-sign APK
       if: ${{ env.ARTIFACT_URL && inputs.re-sign == 'true' }}
       run: |
-        npx rock sign:android ${{ env.ARTIFACT_PATH }} \
+        npx rock sign:android "${{ env.ARTIFACT_PATH }}" \
           --build-jsbundle
       shell: bash
       working-directory: ${{ inputs.working-directory }}
@@ -309,7 +309,7 @@ runs:
     - name: Upload Artifact to Remote Cache for re-signed builds
       if: ${{ env.PROVIDER_NAME != 'GitHub' && inputs.re-sign == 'true' }}
       run: |
-        OUTPUT=$(npx rock remote-cache upload --name ${{ env.ARTIFACT_NAME }} --binary-path ${{ env.ARTIFACT_PATH }} --json --verbose) || (echo "$OUTPUT" && exit 1)
+        OUTPUT=$(npx rock remote-cache upload --name ${{ env.ARTIFACT_NAME }} --binary-path "${{ env.ARTIFACT_PATH }}" --json --verbose) || (echo "$OUTPUT" && exit 1)
         echo "ARTIFACT_URL=$(echo "$OUTPUT" | jq -r '.url')" >> $GITHUB_ENV
       shell: bash
 


### PR DESCRIPTION
This change updates artifact handling logic to support binary paths that include spaces. Without quotes, paths containing spaces would be word-split by bash, breaking the command. 
Adjustment to a similar change in iOS

https://github.com/callstackincubator/ios/pull/23