### PR TITLE
fix(android): use absolute keystore path for android.injected.signing…

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -182,25 +182,6 @@ runs:
       if: ${{ inputs.validate-gradle-wrapper == 'true' && !env.ARTIFACT_URL }}
       uses: gradle/actions/wrapper-validation@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4.4.1
 
-    - name: Create local gradle.properties
-      if: ${{ !env.ARTIFACT_URL && inputs.sign }}
-      run: |
-        mkdir -p $HOME/.gradle
-        touch $HOME/.gradle/gradle.properties
-
-        # Android standard properties (auto-recognized by AGP)
-        echo "android.injected.signing.store.file=${{ inputs.keystore-store-file }}" >> $HOME/.gradle/gradle.properties
-        echo "android.injected.signing.store.password=${{ inputs.keystore-store-password }}" >> $HOME/.gradle/gradle.properties
-        echo "android.injected.signing.key.alias=${{ inputs.keystore-key-alias }}" >> $HOME/.gradle/gradle.properties
-        echo "android.injected.signing.key.password=${{ inputs.keystore-key-password }}" >> $HOME/.gradle/gradle.properties
-
-        # Rock custom properties (for apps that explicitly read them in signingConfigs)
-        echo "ROCK_UPLOAD_STORE_FILE=${{ inputs.keystore-store-file }}" >> $HOME/.gradle/gradle.properties
-        echo "ROCK_UPLOAD_STORE_PASSWORD=${{ inputs.keystore-store-password }}" >> $HOME/.gradle/gradle.properties
-        echo "ROCK_UPLOAD_KEY_ALIAS=${{ inputs.keystore-key-alias }}" >> $HOME/.gradle/gradle.properties
-        echo "ROCK_UPLOAD_KEY_PASSWORD=${{ inputs.keystore-key-password }}" >> $HOME/.gradle/gradle.properties
-      shell: bash
-
     - name: Determine Android sourceDir and appName
       if: ${{ !env.ARTIFACT_URL || (env.ARTIFACT_URL && inputs.re-sign) }}
       run: |
@@ -239,6 +220,25 @@ runs:
         echo "KEYSTORE_TARGET_PATH=$KEYSTORE_TARGET_PATH" >> $GITHUB_ENV
       shell: bash
       working-directory: ${{ inputs.working-directory }}
+
+    - name: Create local gradle.properties
+      if: ${{ !env.ARTIFACT_URL && inputs.sign }}
+      run: |
+        mkdir -p $HOME/.gradle
+        touch $HOME/.gradle/gradle.properties
+
+        # Android standard properties (auto-recognized by AGP).
+        echo "android.injected.signing.store.file=$KEYSTORE_TARGET_PATH" >> $HOME/.gradle/gradle.properties
+        echo "android.injected.signing.store.password=${{ inputs.keystore-store-password }}" >> $HOME/.gradle/gradle.properties
+        echo "android.injected.signing.key.alias=${{ inputs.keystore-key-alias }}" >> $HOME/.gradle/gradle.properties
+        echo "android.injected.signing.key.password=${{ inputs.keystore-key-password }}" >> $HOME/.gradle/gradle.properties
+
+        # Rock custom properties (for apps that explicitly read them in signingConfigs)
+        echo "ROCK_UPLOAD_STORE_FILE=${{ inputs.keystore-store-file }}" >> $HOME/.gradle/gradle.properties
+        echo "ROCK_UPLOAD_STORE_PASSWORD=${{ inputs.keystore-store-password }}" >> $HOME/.gradle/gradle.properties
+        echo "ROCK_UPLOAD_KEY_ALIAS=${{ inputs.keystore-key-alias }}" >> $HOME/.gradle/gradle.properties
+        echo "ROCK_UPLOAD_KEY_PASSWORD=${{ inputs.keystore-key-password }}" >> $HOME/.gradle/gradle.properties
+      shell: bash
 
     - name: Build Android
       if: ${{ !env.ARTIFACT_URL }}


### PR DESCRIPTION
….store.file

When sign=true, the build failed with:

```
Keystore file '/home/runner/.gradle/daemon/9.0.0/release.keystore' not found for signing config 'externalOverride'.
```

It seems like the action wrote only the filename (e.g. release.keystore) to android.injected.signing.store.file. AGP treats it as a path and resolves relative values from the Gradle daemon directory, so it looked in the wrong place.

My Solution:
- Run "Create local gradle.properties" after "Decode and store keystore" so KEYSTORE_TARGET_PATH (absolute path) is available.
- Set android.injected.signing.store.file=$KEYSTORE_TARGET_PATH instead of the bare filename. AGP's externalOverride then finds the keystore.

ROCK_UPLOAD_* and other signing properties are unchanged.