### PR TITLE
feat: add validate-elf-alignment command

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -71,6 +71,10 @@ inputs:
   custom-identifier:
     description: 'Custom identifier used in artifact naming for re-sign and ad-hoc flows to distinguish builds with the same native fingerprint'
     required: false
+  validate-elf-alignment:
+    description: 'Validate ELF alignment of native libraries (16KB page size compliance for Google Play)'
+    required: false
+    default: 'false'
 
 outputs:
   artifact-url:
@@ -269,6 +273,13 @@ runs:
         echo BINARY_PATH $BINARY_PATH
         echo "ARTIFACT_PATH=$BINARY_PATH" >> $GITHUB_ENV
       shell: bash
+
+    - name: Validate ELF Alignment
+      if: ${{ inputs.validate-elf-alignment == 'true' && !env.ARTIFACT_URL && env.ARTIFACT_PATH }}
+      run: |
+        npx rock validate-elf-alignment "${{ env.ARTIFACT_PATH }}"
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
 
     - name: Download and Unpack Binary
       if: ${{ env.ARTIFACT_URL && inputs.re-sign == 'true' }}


### PR DESCRIPTION
Adds optional check for ELF validation of .apk file based on new rock command: `validate-elf-alignment` https://github.com/callstackincubator/rock/pull/686

- only when `validate-elf-alignment: true`
- only for fresh build

