### PR TITLE
fix: propagate working-directory input to all composite action steps

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -149,6 +149,7 @@ runs:
         mkdir -p .rock/cache
         echo "{\"githubToken\": \"${{ inputs.github-token }}\"}" > .rock/cache/project.json
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
     # We create PR-related artifacts to avoid overwriting the main artifact with new JS bundle
     - name: Check if PR-related artifact exists
       if: ${{ github.event_name == 'pull_request' && inputs.re-sign == 'true' }}
@@ -163,6 +164,7 @@ runs:
           echo "ARTIFACT_NAME=$(echo "$OUTPUT" | jq -r '.name')" >> $GITHUB_ENV
         fi
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
 
     - name: Check if regular artifact exists
       if: ${{ !env.ARTIFACT_NAME }}
@@ -177,6 +179,7 @@ runs:
           echo "ARTIFACT_NAME=$(echo "$OUTPUT" | jq -r '.name')" >> $GITHUB_ENV
         fi
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
     - name: Set Artifact Name (if not set)
       if: ${{ !env.ARTIFACT_NAME }}
       run: |
@@ -273,6 +276,7 @@ runs:
         echo BINARY_PATH $BINARY_PATH
         echo "ARTIFACT_PATH=$BINARY_PATH" >> $GITHUB_ENV
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
 
     - name: Validate ELF Alignment
       if: ${{ inputs.validate-elf-alignment == 'true' && !env.ARTIFACT_URL && env.ARTIFACT_PATH }}
@@ -288,6 +292,7 @@ runs:
         BINARY_PATH=$(echo "$DOWNLOAD_OUTPUT" | jq -r '.path')
         echo "ARTIFACT_PATH=$BINARY_PATH" >> $GITHUB_ENV
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
 
     - name: Re-sign Binary
       if: ${{ env.ARTIFACT_URL && inputs.re-sign == 'true' }}
@@ -341,6 +346,7 @@ runs:
           echo "ARTIFACT_ID=$(echo "$OUTPUT" | jq -r '.id')" >> $GITHUB_ENV
         fi
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
     # Special case for GitHub, as it doesn't support uploading through the API
     - name: Upload Artifact to GitHub
       id: upload-artifact
@@ -360,6 +366,7 @@ runs:
         OUTPUT=$(npx rock remote-cache upload --name ${{ env.ARTIFACT_NAME }} --binary-path "${{ env.ARTIFACT_PATH }}" --json --verbose) || (echo "$OUTPUT" && exit 1)
         echo "ARTIFACT_URL=$(echo "$OUTPUT" | jq -r '.url')" >> $GITHUB_ENV
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
 
     # Upload ZIP Artifact with {fingerprint}-only name as base ZIP Artifact for caching only (first build only).
     # Runs only when no cached artifact exists (!ARTIFACT_URL), meaning native build was done from scratch.
@@ -373,6 +380,7 @@ runs:
         OUTPUT=$(npx rock remote-cache upload --name ${{ env.ARTIFACT_NAME }} --json --verbose) || (echo "$OUTPUT" && exit 1)
         echo "ARTIFACT_URL=$(echo "$OUTPUT" | jq -r '.url')" >> $GITHUB_ENV
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
 
 
     # Ad-hoc uploads always include an identifier in the name {identifier}-{fingerprint}
@@ -392,12 +400,14 @@ runs:
         OUTPUT=$(npx rock remote-cache upload --name ${{ env.ADHOC_ARTIFACT_NAME }} --binary-path "${{ env.ARTIFACT_PATH }}" --json --ad-hoc) || (echo "$OUTPUT" && exit 1)
         echo "ARTIFACT_URL=$(echo "$OUTPUT" | jq -r '.url')" >> $GITHUB_ENV
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
 
     - name: Delete Old Re-Signed Artifacts
       if: ${{ env.ARTIFACT_URL && inputs.re-sign == 'true' && github.event_name == 'pull_request' }}
       run: |
         npx rock remote-cache delete --name ${{ env.ARTIFACT_NAME }} --all-but-latest --json
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
 
     - name: Clean Up Keystore
       if: ${{ (!env.ARTIFACT_URL && inputs.sign) || (env.ARTIFACT_URL && inputs.re-sign) }}


### PR DESCRIPTION
## Summary

The `working-directory` input is accepted by the action but was not propagated to 10 out of ~20 composite steps. Any step that runs `npx rock remote-cache ...` or touches `.rock/cache` with a relative path would fail with `rock.config not found` when the consuming repo's app lives in a subdirectory (i.e. `working-directory` != `.`).

**Steps fixed (added `working-directory: ${{ inputs.working-directory }}`):**

- Populate GitHub Token in Cache
- Check if PR-related artifact exists
- Check if regular artifact exists
- Find Build Artifact
- Download and Unpack Binary
- Find artifact URL again before uploading
- Upload re-signed ZIP Artifact for non-ad-hoc flow
- Upload ZIP Artifact for caching
- Upload for Ad-hoc distribution
- Delete Old Re-Signed Artifacts

Steps that were already correct (had `working-directory` or don't need it) were left untouched.

Closes #24